### PR TITLE
fix: update CI Python version, pin actions, add Renovate

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,11 +8,11 @@ jobs:
     name: update awesome-stars
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
-        python-version: 3.7
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": [
+    "github-actions"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Python 3.7 → 3.12（3.7はEOL済みでランナーから削除されたためCIが失敗していた）
- `actions/checkout` v1 → v4、`actions/setup-python` v1 → v5（コミットSHAピン留め）
- Renovate設定を追加（GitHub Actionsのみ対象、minor/patchは自動マージ）

## Test plan
- [ ] CIワークフローが正常に実行されることを確認（手動トリガーで検証）
- [x] Renovate Appがインストール済みであることを確認